### PR TITLE
Austrian numeric date format

### DIFF
--- a/datetime2-german/datetime2-german.dtx
+++ b/datetime2-german/datetime2-german.dtx
@@ -1613,7 +1613,7 @@
 %\begin{macro}{\DTMdeATdatesep}
 % The separator for the numeric date format.
 %    \begin{macrocode}
-\newcommand*{\DTMdeATdatesep}{-}
+\newcommand*{\DTMdeATdatesep}{.}
 %    \end{macrocode}
 %\end{macro}
 %
@@ -1786,19 +1786,28 @@
 {de-AT-numeric}% label
 {% date style
   \renewcommand*\DTMdisplaydate[4]{%
-    \DTMifbool{de-AT}{showyear}%
-    {%
-      \number##1 % space intended
-      \DTMdeATdatesep%
-    }%
-    {}%
-    %
-    \DTMtwodigits{##2}%
+    \ifDTMshowdow
+      \ifnum##4>-1
+        \DTMifbool{de-AT}{abbr}%
+        {\DTMgermanshortweekdayname{##4}}%
+        {\DTMgermanweekdayname{##4}}%
+        \DTMdeATdowdaysep
+      \fi
+    \fi
     %
     \DTMifbool{de-AT}{showdayofmonth}%
     {%
-      \DTMdeATdatesep%
       \DTMtwodigits{##3}%
+      \DTMdeATdatesep
+    }%
+    {}%
+    \DTMtwodigits{##2}%
+    \DTMdeATdatesep%
+    \DTMifbool{de-AT}{showyear}%
+    {%
+      \DTMifbool{de-AT}{abbr}%
+      {\DTMtwodigits{##1}}%
+      {\number##1 }% space intended
     }%
     {}%
   }%


### PR DESCRIPTION
First of all, thanks for maintaining this package!

I was surprised when I tried to use the style de-AT-numeric and it looked just like ISO (yyyy-mm-dd). So I have copied de-DE-numeric and basically replaced every DE with AT since the German style is no different from the Austrian one. The only difference I'm aware of is "Januar/Jänner". In any case, no Austrian uses dashes as a date separator, always dots.